### PR TITLE
Add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: ruby
+
+rvm:
+  - 2.6.3
+
+env:
+  global:
+    - RAILS_ENV=test
+
+cache:
+  yarn: true
+
+before_install:
+  - nvm install 11
+  - gem install bundler
+
+before_script:
+  - yarn install
+  - gem install bundle-audit
+
+script:
+  - RAILS_ENV=test bundle exec rake db:test:prepare
+  - bundle exec rspec
+  - bundle exec rubocop --config .rubocop.yml
+  - bundle-audit check --update


### PR DESCRIPTION
Nessa branch eu estou habilitando a integração contínua usando a ferramenta Travis CI. A partir de agora cada dev precisa criar sua conta em https://travis-ci.com para acompanhar os `builds` do projeto.


Para fazer a configuração eu utilizei a documentação oficial do Travis: https://docs.travis-ci.com/user/languages/ruby/



