### PR TITLE
[Admin/View] Incluir opção de cadastrar empresas.

### DIFF
--- a/app/views/payment_methods/index.html.erb
+++ b/app/views/payment_methods/index.html.erb
@@ -3,6 +3,7 @@
 
 <% if admin_signed_in? %>
   <%= link_to 'Cadastrar novo meio de pagamento', new_payment_method_path %>
+  <%= link_to 'Vincular Empresas', new_admin_payment_company_path %>
 <% end %>
 
 <% if @payment_methods.any? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,13 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-client = Client.create(email:'test@test.com', password: '123teste')
+client = Client.create(email:'client@teste.com', password: '123teste')
 ClientProfile.create(cnpj: '111111111-11', company_name: 'Empresa A', 
                      manager: 'Fulano', address: 'Paulista, 1000', 
                      phone: '11-2999-9999', auth_token: 'adhfad12123', 
                      client_id: client.id) 
+
+Admin.create(email: 'admin@teste.com', password: '123teste')
 
 debito = PaymentMethod.create(name: 'Débito em Conta', tax: 0.01)
 pay_co01 = PaymentCompany.create(name: 'MasterCard',

--- a/spec/features/admin/admin_register_payment_company_spec.rb
+++ b/spec/features/admin/admin_register_payment_company_spec.rb
@@ -6,7 +6,10 @@ context 'admin register payment company' do
     admin = create(:admin)
     login_as(admin, scope: :admin)
 
-    visit new_admin_payment_company_path
+    visit root_path
+    click_on 'Meios de pagamento'
+    click_on 'Vincular Empresas'
+
     fill_in 'Bandeira/Banco/Serviço', with: 'Mastercard'
     attach_file 'Image', Rails.root.join('spec/support/mastercard.png')
     select 'Débito', from: 'Metodo de pagamento'


### PR DESCRIPTION
Criar a opção de cadastrar uma empresa(bandeira/banco/serviço) a um metodo de pagamento.

Referente ao card: https://trello.com/c/sy36rsIP/35-admin-view-registrar-empresa-de-pagamento

Co-authored-by: Rubens <igesca.rubens@gmail.com>